### PR TITLE
fix issue149 TypeError _.contains caused by lodash

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -58,6 +58,11 @@ module.exports = {
   module: {
     rules: [
       {
+        parser: {
+          amd: false,
+        }
+      },
+      {
         test: /\.(ts|tsx)$/,
         loaders: require.resolve('tslint-loader'),
         enforce: 'pre',


### PR DESCRIPTION
-Fix issue 149 caused by lodash issue described here:
https://github.com/lodash/lodash/issues/1798
with fix here:
https://github.com/webpack/webpack/issues/3017#issuecomment-285954512