### PR TITLE
sWW 1.2.1->1.3.1 upversioning error

### DIFF
--- a/src/background/controllers/cryptoController.ts
+++ b/src/background/controllers/cryptoController.ts
@@ -88,8 +88,7 @@ export default class CryptoController extends IController {
         if (e.data.err) {
           throw Error('scrypt failed to calculate derivedKey');
         }
-        const derivedKey = e.data.derivedKey;
-        this.passwordHash = derivedKey.toString('hex');
+        this.passwordHash = e.data.passwordHash;
         this.main.account.finishLogin();
       };
     }

--- a/src/background/workers/scryptworker.js
+++ b/src/background/workers/scryptworker.js
@@ -7,7 +7,8 @@ onmessage = (e) => {
     const saltBuffer = Buffer.from(salt);
     const { N, r, p } = e.data.scryptParams;
     const derivedKey = scrypt(password, saltBuffer, N, r, p, 64);
-    postMessage({ derivedKey });
+    const passwordHash = derivedKey.toString('hex');
+    postMessage({ passwordHash });
   } catch (err) {
     postMessage({ err });
   }

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Qrypto",
   "description": "Qtum light wallet and transaction signing client.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "manifest_version": 2,
   "icons": {
     "16": "images/logo-main-16.png",


### PR DESCRIPTION
-have scryptWebWorker send back passwordHash instead of derivedKey, this resolves the problem where upversioning from 1.2.1->1.3.1  would cause an invalid password error without a reinstall