### PR TITLE
add regtest network

### DIFF
--- a/src/background/controllers/networkController.ts
+++ b/src/background/controllers/networkController.ts
@@ -9,6 +9,7 @@ export default class NetworkController extends IController {
   public static NETWORKS: QryNetwork[] = [
     new QryNetwork(NETWORK_NAMES.MAINNET, networks.mainnet, 'https://explorer.qtum.org/tx'),
     new QryNetwork(NETWORK_NAMES.TESTNET, networks.testnet, 'https://testnet.qtum.org/tx'),
+    new QryNetwork(NETWORK_NAMES.REGTEST, networks.regtest, 'http://localhost:3001/explorer/tx'),
   ];
 
   public get isMainNet(): boolean {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -104,6 +104,7 @@ export enum SEND_STATE {
 }
 
 export enum NETWORK_NAMES {
+  REGTEST = 'RegTest',
   TESTNET = 'TestNet',
   MAINNET = 'MainNet',
 }


### PR DESCRIPTION
rebased dcb9's regtest pr

3001 is the default insight api port
https://insight.is/
https://github.com/qtumproject/insight-api