### PR TITLE
dialogbox height, tokenBal trunc on accountDetail, fractional on Send (issue178)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,14 +107,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bn.js": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.1.tgz",
-      "integrity": "sha512-ialVHUVjhSH/96vKDd20XGokJ9ktVdeBrDY5w7hpHva/2ZiB3ZhZ4VZQOmSYe/vpZEkDy+ydtr9hMckxw+/MMw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/chrome": {
       "version": "0.0.63",
       "resolved": "http://registry.npmjs.org/@types/chrome/-/chrome-0.0.63.tgz",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "@material-ui/icons": "^1.1.0",
     "@types/bip39": "^2.4.0",
-    "@types/bn.js": "^4.11.1",
     "@types/history": "^4.6.2",
     "@types/lodash": "^4.14.110",
     "@types/qrcode.react": "^0.8.0",

--- a/src/background/controllers/tokenController.ts
+++ b/src/background/controllers/tokenController.ts
@@ -120,7 +120,7 @@ export default class TokenController extends IController {
     // Decode result
     const decodedRes = qweb3.decoder.decodeCall(result, qrc20TokenABI, methodName);
     const bnBal = decodedRes!.executionResult.formattedOutput[0]; // Returns as a BN instance
-    const bigNumberBal = new BigNumber(bnBal.toNumber()); // Convert to BigNumber instance
+    const bigNumberBal = new BigNumber(bnBal.toString(10)); // Convert to BigNumber instance
     const balance = bigNumberBal.dividedBy(new BigNumber(10 ** token.decimals)).toNumber(); // Convert to regular denomination
 
     // Update token balance in place

--- a/src/background/controllers/tokenController.ts
+++ b/src/background/controllers/tokenController.ts
@@ -1,5 +1,4 @@
 import { each, findIndex, isEmpty } from 'lodash';
-import BN from 'bn.js';
 import BigNumber from 'bignumber.js';
 import { Insight } from 'qtumjs-wallet';
 const { Qweb3 } = require('qweb3');
@@ -120,8 +119,9 @@ export default class TokenController extends IController {
 
     // Decode result
     const decodedRes = qweb3.decoder.decodeCall(result, qrc20TokenABI, methodName);
-    let balance = decodedRes!.executionResult.formattedOutput[0]; // Returns as a BN instance
-    balance = balance.div(new BN(10 ** token.decimals)).toNumber(); // Convert to regular denomination
+    const bnBal = decodedRes!.executionResult.formattedOutput[0]; // Returns as a BN instance
+    const bigNumberBal = new BigNumber(bnBal.toNumber()); // Convert to BigNumber instance
+    const balance = bigNumberBal.dividedBy(new BigNumber(10 ** token.decimals)).toNumber(); // Convert to regular denomination
 
     // Update token balance in place
     const index = findIndex(this.tokens, { name: token.name, symbol: token.symbol });

--- a/src/inpage/window.ts
+++ b/src/inpage/window.ts
@@ -34,5 +34,5 @@ export function showSignTxWindow(signTxReq: ISignExternalTxRequest) {
 
   const reqStr = JSON.stringify(request);
   const params = `req=${reqStr}&from=${account.address}`;
-  showWindow(350, 550, `${url}?${params}`, 'Confirm Transaction');
+  showWindow(350, 650, `${url}?${params}`, 'Confirm Transaction');
 }

--- a/src/popup/pages/AccountDetail/index.tsx
+++ b/src/popup/pages/AccountDetail/index.tsx
@@ -128,8 +128,8 @@ const TokenList: SFC<any> = observer(({ classes,
         <div className={classes.tokenInfoContainer}>
           <Typography className={classes.tokenName}>{name}</Typography>
         </div>
-        <AmountInfo classes={classes} amount={ balance === undefined || balance < 1
-          ? balance : Math.trunc(balance) } token={symbol} convertedValue={0} />
+        <AmountInfo classes={classes} amount={balance === undefined || balance < 1
+          ? balance : Math.trunc(balance)} token={symbol} convertedValue={0} />
       </ListItem>
     ))}
     <div className={classes.bottomButtonWrap}>

--- a/src/popup/pages/AccountDetail/index.tsx
+++ b/src/popup/pages/AccountDetail/index.tsx
@@ -128,7 +128,8 @@ const TokenList: SFC<any> = observer(({ classes,
         <div className={classes.tokenInfoContainer}>
           <Typography className={classes.tokenName}>{name}</Typography>
         </div>
-        <AmountInfo classes={classes} amount={balance} token={symbol} convertedValue={0} />
+        <AmountInfo classes={classes} amount={ balance === undefined || balance < 1
+          ? balance : Math.trunc(balance) } token={symbol} convertedValue={0} />
       </ListItem>
     ))}
     <div className={classes.bottomButtonWrap}>


### PR DESCRIPTION
-Increase height of confirm transaction dialogbox (resolves issue178)
-Convert bn.js to BigNumber.js  for token balances, truncate the balance on the account detail page, fractional balance on Send page(resolves issue 179)
@dwalintukan decided not to do the "< 1"  and to just show the fractional balance after talking to lili ( we have enough space)